### PR TITLE
slight tweaks made while replacing squares with chessground in mobile

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -155,6 +155,11 @@ class Move {
     );
   }
 
+  Move.make(String uci)
+      : from = uci.substring(0, 2),
+        to = uci.substring(2, 4),
+        promotion = uci.length > 4 ? _toRole(uci.substring(4)) : null;
+
   @override
   bool operator ==(Object other) {
     return other.runtimeType == runtimeType && hashCode == other.hashCode;
@@ -162,17 +167,6 @@ class Move {
 
   @override
   int get hashCode => hashValues(from, to, promotion);
-
-  static Move? make(String? uci) {
-    if (uci == null) {
-      return null;
-    } else {
-      return Move(
-          from: uci.substring(0, 2),
-          to: uci.substring(2, 4),
-          promotion: uci.length > 4 ? _toRole(uci.substring(4)) : null);
-    }
-  }
 }
 
 String _toLetter(PieceRole? role, [Color color = Color.white]) {

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -78,17 +78,7 @@ class Piece {
 
   String get kind => '${color.name}_${role.name}';
   String get roleLetter {
-    return role == PieceRole.king
-        ? 'K'
-        : role == PieceRole.queen
-            ? 'Q'
-            : role == PieceRole.rook
-                ? 'R'
-                : role == PieceRole.bishop
-                    ? 'B'
-                    : role == PieceRole.knight
-                        ? 'K'
-                        : 'P';
+    return _toLetter(role);
   }
 
   Piece copyWith({
@@ -151,13 +141,13 @@ class Move {
 
   final SquareId from;
   final SquareId to;
-  final Piece? promotion;
+  final PieceRole? promotion;
 
   List<SquareId> get squares => List.unmodifiable([from, to]);
 
-  String get uci => '$from$to${promotion?.roleLetter ?? ''}';
+  String get uci => '$from$to${_toLetter(promotion)}';
 
-  Move withPromotion(Piece promotion) {
+  Move withPromotion(PieceRole promotion) {
     return Move(
       from: from,
       to: to,
@@ -172,4 +162,52 @@ class Move {
 
   @override
   int get hashCode => hashValues(from, to, promotion);
+
+  static Move? make(String? uci) {
+    if (uci == null) {
+      return null;
+    } else {
+      return Move(
+          from: uci.substring(0, 2),
+          to: uci.substring(2, 4),
+          promotion: uci.length > 4 ? _toRole(uci.substring(4)) : null);
+    }
+  }
+}
+
+String _toLetter(PieceRole? role, [Color color = Color.white]) {
+  bool isWhite = color == Color.white;
+  switch (role) {
+    case PieceRole.king:
+      return isWhite ? 'K' : 'k';
+    case PieceRole.queen:
+      return isWhite ? 'Q' : 'q';
+    case PieceRole.rook:
+      return isWhite ? 'R' : 'r';
+    case PieceRole.bishop:
+      return isWhite ? 'B' : 'b';
+    case PieceRole.knight:
+      return isWhite ? 'N' : 'n';
+    case PieceRole.pawn:
+      return isWhite ? 'P' : 'p';
+    case null:
+      return '';
+  }
+}
+
+PieceRole _toRole(String uciLetter) {
+  switch (uciLetter.trim().toLowerCase()) {
+    case 'k':
+      return PieceRole.king;
+    case 'q':
+      return PieceRole.queen;
+    case 'r':
+      return PieceRole.rook;
+    case 'b':
+      return PieceRole.bishop;
+    case 'n':
+      return PieceRole.knight;
+    default:
+      return PieceRole.pawn;
+  }
 }

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -248,7 +248,7 @@ class _BoardState extends State<Board> {
       pieces[move.to] = promoted;
       _promotionMove = null;
     });
-    widget.onMove?.call(move.withPromotion(promoted));
+    widget.onMove?.call(move.withPromotion(promoted.role));
   }
 
   void _onPromotionCancel(cg.Move move) {
@@ -293,10 +293,7 @@ class _BoardState extends State<Board> {
       }
       if (_isPromoMove(selectedPiece, squareId)) {
         if (widget.settings.autoQueenPromotion) {
-          widget.onMove?.call(move.withPromotion(cg.Piece(
-              role: cg.PieceRole.queen,
-              color: widget.turnColor,
-              promoted: true)));
+          widget.onMove?.call(move.withPromotion(cg.PieceRole.queen));
         } else {
           _openPromotionSelector(move);
         }


### PR DESCRIPTION
Hi Vincent, I don't know if you're seeking pull requests at this early stage but I was replacing squares & bishop with your chessground in a mobile (tv stream) prototype and made some changes that simplify client code.  Basically, a make from uci string static in Move and also made Move.promotion a PieceRole rather than a Piece.